### PR TITLE
Add CORS permission in header via netlify.toml configuration file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover. No restriction here to share with the most
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
According to this documentation https://docs.netlify.com/configure-builds/file-based-configuration/ it should be enough to enable CORS. Even tough I was not able to test it, it should do the trick.