### PR TITLE
use yarn lint instead of npm eslint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
         run: yarn
       - name: "Run linter"
         run: |
-          yarn lint
+          yarn lint --no-fix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: '14'
       - name: "Install packages"
-        run: npm install
-      - name: "Run eslint"
+        run: yarn
+      - name: "Run linter"
         run: |
-          ./node_modules/.bin/eslint --fix src
+          yarn lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
         run: yarn
       - name: "Run linter"
         run: |
-          yarn lint --no-fix
+          yarn lint --no-fix --max-warnings 20


### PR DESCRIPTION
Je pense que c'est mieux de

- conserver l'usage de yarn partout
- d'utiliser la commande yarn lint car c'est celle utilisé par le développeur en local
- d'utiliser la commande --no-fix car elle va afficher les problème, on ne veux pas les masquer ou vraiment les réparer en fait