### PR TITLE
Add sort option on columns effectif and Dates in search result page

### DIFF
--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -5,24 +5,11 @@
         <tr>
           <th>Dénomination</th>
           <th>
-            <SortArrowTitle
-              :sortOrder="sortOrderForField(FIELD_TRI_EFFECTIF)"
-              @sortOrderChanged="
-                (order) =>
-                  handleSortOrderChangeForField(FIELD_TRI_EFFECTIF)(order)
-              "
-              name="Effectif"
-            />
+            <SortableTitle v-model="sortOrderEffectif" name="Effectif" />
           </th>
           <th>Secteur (code APE)</th>
           <th>
-            <SortArrowTitle
-              :sortOrder="sortOrderForField(FIELD_TRI_DATE)"
-              @sortOrderChanged="
-                (order) => handleSortOrderChangeForField(FIELD_TRI_DATE)(order)
-              "
-              name="Dates"
-            />
+            <SortableTitle v-model="sortOrderDate" name="Dates" />
           </th>
           <th>SIREN</th>
         </tr>
@@ -55,13 +42,13 @@
 </template>
 
 <script>
-import SortArrowTitle from "./SortableTitle.vue";
+import SortableTitle from "./SortableTitle.vue";
 
 const FIELD_TRI_EFFECTIF = "trancheeffectifsunitelegaletriable";
 const FIELD_TRI_DATE = "datecreationunitelegale";
 
 export default {
-  components: { SortArrowTitle },
+  components: { SortableTitle },
   props: {
     companies: {
       type: Array,
@@ -75,30 +62,29 @@ export default {
   },
   data() {
     return {
-      FIELD_TRI_EFFECTIF,
-      FIELD_TRI_DATE,
+      sortOrderDate: this.getSortOrder(FIELD_TRI_DATE),
+      sortOrderEffectif: this.getSortOrder(FIELD_TRI_EFFECTIF),
     };
   },
-  methods: {
-    sortOrderForField(field) {
-      if (this.sort?.field === field) return this.sort?.order;
-      return null;
+  watch: {
+    sortOrderDate(order) {
+      this.emitSortOrderChange(FIELD_TRI_DATE, order);
     },
+    sortOrderEffectif(order) {
+      this.emitSortOrderChange(FIELD_TRI_EFFECTIF, order);
+    },
+  },
+  methods: {
     companyDetailRoute: (company) => ({
       name: "Detail",
       params: { siren: company.fields.siren },
     }),
-
-    handleSortOrderChangeForField(field) {
-      return (order) => {
-        // console.log("EMIT sortChanged", { field, order });
-        this.$emit("sortChanged", { field, order });
-      };
-    },
-    rollSortValue(val) {
-      if (val === null || val === "") return true;
-      if (val === true) return false;
+    getSortOrder(field) {
+      if (this.sort?.field === field) return this.sort?.order;
       return null;
+    },
+    emitSortOrderChange(field, order) {
+      this.$emit("sortChanged", { field, order });
     },
     getEffectif(company) {
       if (!company.fields.trancheeffectifsunitelegale) {

--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -4,9 +4,13 @@
       <thead>
         <tr>
           <th>Dénomination</th>
-          <th>Effectif</th>
+          <router-link class="result-link" :to="effectifSortRoute()">
+            <th>Effectif</th>
+          </router-link>
           <th>Secteur (code APE)</th>
-          <th>Dates</th>
+          <router-link class="result-link" :to="dateCreationSortRoute()">
+            <th>Dates</th>
+          </router-link>
           <th>SIREN</th>
         </tr>
       </thead>
@@ -48,6 +52,11 @@ export default {
     effectifSortRoute() {
       var route = { ...this.$route };
       route.query["sort"] = "trancheeffectifsunitelegaletriable";
+      return route;
+    },
+    dateCreationSortRoute() {
+      var route = { ...this.$route };
+      route.query["sort"] = "datecreationunitelegale";
       return route;
     },
     getEffectif(company) {

--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -43,9 +43,10 @@
 
 <script>
 import SortableTitle from "./SortableTitle.vue";
+import OpenDataSoftSearchRepository from "@/repositories/search/OpenDataSoftSearchRepository";
 
-const FIELD_TRI_EFFECTIF = "trancheeffectifsunitelegaletriable";
-const FIELD_TRI_DATE = "datecreationunitelegale";
+const { FIELD_TRI_EFFECTIF, FIELD_TRI_DATE } =
+  OpenDataSoftSearchRepository.fields;
 
 export default {
   components: { SortableTitle },
@@ -67,6 +68,10 @@ export default {
     };
   },
   watch: {
+    sort() {
+      this.sortOrderDate = this.getSortOrder(FIELD_TRI_DATE);
+      this.sortOrderEffectif = this.getSortOrder(FIELD_TRI_EFFECTIF);
+    },
     sortOrderDate(order) {
       this.emitSortOrderChange(FIELD_TRI_DATE, order);
     },
@@ -80,6 +85,11 @@ export default {
       params: { siren: company.fields.siren },
     }),
     getSortOrder(field) {
+      console.log("getSortOrder", {
+        sort: this.sort,
+        field,
+        order: this.sort?.order,
+      });
       if (this.sort?.field === field) return this.sort?.order;
       return null;
     },

--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -6,16 +6,21 @@
           <th>Dénomination</th>
           <th>
             <SortArrowTitle
-              :sort="sortEffectif"
-              @sortChanged="handleSortEffectifChange"
+              :sortOrder="sortOrderForField(FIELD_TRI_EFFECTIF)"
+              @sortOrderChanged="
+                (order) =>
+                  handleSortOrderChangeForField(FIELD_TRI_EFFECTIF)(order)
+              "
               name="Effectif"
             />
           </th>
           <th>Secteur (code APE)</th>
           <th>
             <SortArrowTitle
-              :sort="sortDate"
-              @sortChanged="handleSortDateChange"
+              :sortOrder="sortOrderForField(FIELD_TRI_DATE)"
+              @sortOrderChanged="
+                (order) => handleSortOrderChangeForField(FIELD_TRI_DATE)(order)
+              "
               name="Dates"
             />
           </th>
@@ -62,27 +67,33 @@ export default {
       type: Array,
       required: true,
     },
-    sortEffectif: {
-      type: Boolean,
-      default: null,
-      required: false,
-    },
-    sortDate: {
-      type: Boolean,
+    sort: {
+      type: Object,
       default: null,
       required: false,
     },
   },
+  data() {
+    return {
+      FIELD_TRI_EFFECTIF,
+      FIELD_TRI_DATE,
+    };
+  },
   methods: {
+    sortOrderForField(field) {
+      if (this.sort?.field === field) return this.sort?.order;
+      return null;
+    },
     companyDetailRoute: (company) => ({
       name: "Detail",
       params: { siren: company.fields.siren },
     }),
-    handleSortEffectifChange(order) {
-      this.$emit("sortChanged", { field: FIELD_TRI_EFFECTIF, order });
-    },
-    handleSortDateChange(order) {
-      this.$emit("sortChanged", { field: FIELD_TRI_DATE, order });
+
+    handleSortOrderChangeForField(field) {
+      return (order) => {
+        // console.log("EMIT sortChanged", { field, order });
+        this.$emit("sortChanged", { field, order });
+      };
     },
     rollSortValue(val) {
       if (val === null || val === "") return true;

--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -5,11 +5,24 @@
         <tr>
           <th>Dénomination</th>
           <th>
-            <SortableTitle v-model="sortOrderEffectif" name="Effectif" />
+            <SortableTitle
+              :sortOrder="sortOrderForField(FIELD_TRI_EFFECTIF)"
+              @sortOrderChanged="
+                (order) =>
+                  handleSortOrderChangeForField(FIELD_TRI_EFFECTIF)(order)
+              "
+              name="Effectif"
+            />
           </th>
           <th>Secteur (code APE)</th>
           <th>
-            <SortableTitle v-model="sortOrderDate" name="Dates" />
+            <SortableTitle
+              :sortOrder="sortOrderForField(FIELD_TRI_DATE)"
+              @sortOrderChanged="
+                (order) => handleSortOrderChangeForField(FIELD_TRI_DATE)(order)
+              "
+              name="Dates"
+            />
           </th>
           <th>SIREN</th>
         </tr>
@@ -63,27 +76,25 @@ export default {
   },
   data() {
     return {
-      sortOrderDate: this.getSortOrder(FIELD_TRI_DATE),
-      sortOrderEffectif: this.getSortOrder(FIELD_TRI_EFFECTIF),
+      FIELD_TRI_EFFECTIF,
+      FIELD_TRI_DATE,
     };
   },
-  watch: {
-    sort() {
-      this.sortOrderDate = this.getSortOrder(FIELD_TRI_DATE);
-      this.sortOrderEffectif = this.getSortOrder(FIELD_TRI_EFFECTIF);
-    },
-    sortOrderDate(order) {
-      this.emitSortOrderChange(FIELD_TRI_DATE, order);
-    },
-    sortOrderEffectif(order) {
-      this.emitSortOrderChange(FIELD_TRI_EFFECTIF, order);
-    },
-  },
   methods: {
+    sortOrderForField(field) {
+      if (this.sort?.field === field) return this.sort?.order;
+      return null;
+    },
     companyDetailRoute: (company) => ({
       name: "Detail",
       params: { siren: company.fields.siren },
     }),
+    handleSortOrderChangeForField(field) {
+      return (order) => {
+        // console.log("EMIT sortChanged", { field, order });
+        this.$emit("sortChanged", { field, order });
+      };
+    },
     getSortOrder(field) {
       console.log("getSortOrder", {
         sort: this.sort,

--- a/src/components/search/OpenDataSoftResultList.vue
+++ b/src/components/search/OpenDataSoftResultList.vue
@@ -4,13 +4,21 @@
       <thead>
         <tr>
           <th>Dénomination</th>
-          <router-link class="result-link" :to="effectifSortRoute()">
-            <th>Effectif</th>
-          </router-link>
+          <th>
+            <SortArrowTitle
+              :sort="sortEffectif"
+              @sortChanged="handleSortEffectifChange"
+              name="Effectif"
+            />
+          </th>
           <th>Secteur (code APE)</th>
-          <router-link class="result-link" :to="dateCreationSortRoute()">
-            <th>Dates</th>
-          </router-link>
+          <th>
+            <SortArrowTitle
+              :sort="sortDate"
+              @sortChanged="handleSortDateChange"
+              name="Dates"
+            />
+          </th>
           <th>SIREN</th>
         </tr>
       </thead>
@@ -42,22 +50,44 @@
 </template>
 
 <script>
+import SortArrowTitle from "./SortableTitle.vue";
+
+const FIELD_TRI_EFFECTIF = "trancheeffectifsunitelegaletriable";
+const FIELD_TRI_DATE = "datecreationunitelegale";
+
 export default {
-  props: ["companies"],
+  components: { SortArrowTitle },
+  props: {
+    companies: {
+      type: Array,
+      required: true,
+    },
+    sortEffectif: {
+      type: Boolean,
+      default: null,
+      required: false,
+    },
+    sortDate: {
+      type: Boolean,
+      default: null,
+      required: false,
+    },
+  },
   methods: {
     companyDetailRoute: (company) => ({
       name: "Detail",
       params: { siren: company.fields.siren },
     }),
-    effectifSortRoute() {
-      var route = { ...this.$route };
-      route.query["sort"] = "trancheeffectifsunitelegaletriable";
-      return route;
+    handleSortEffectifChange(order) {
+      this.$emit("sortChanged", { field: FIELD_TRI_EFFECTIF, order });
     },
-    dateCreationSortRoute() {
-      var route = { ...this.$route };
-      route.query["sort"] = "datecreationunitelegale";
-      return route;
+    handleSortDateChange(order) {
+      this.$emit("sortChanged", { field: FIELD_TRI_DATE, order });
+    },
+    rollSortValue(val) {
+      if (val === null || val === "") return true;
+      if (val === true) return false;
+      return null;
     },
     getEffectif(company) {
       if (!company.fields.trancheeffectifsunitelegale) {

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -49,9 +49,8 @@
         <OpenDataSoftResultList
           v-if="SearchEngine == 'OpenDataSoft'"
           :companies="items"
-          :sortEffectif="sortEffectif"
-          :sortDate="sortDate"
-          @sortChanged="handleSortChanged"
+          :sort="sortData"
+          @sortChanged="handleSortChange"
         />
         <EnthicResultList v-if="SearchEngine == 'Enthic'" :companies="items" />
       </div>
@@ -146,12 +145,16 @@ export default {
     sortEffectif() {
       if (this.SearchEngine !== "OpenDataSoft") return null;
       const sort = this.readSortQuery(this.$route.query.sort);
-      return sort?.field === "effectif" ? sort.order : null;
+      return sort?.field === FIELD_TRI_EFFECTIF ? sort.order : null;
     },
     sortDate() {
       if (this.SearchEngine !== "OpenDataSoft") return null;
       const sort = this.readSortQuery(this.$route.query.sort);
-      return sort?.field === "date" ? sort.order : null;
+      return sort?.field === FIELD_TRI_DATE ? sort.order : null;
+    },
+    sortData() {
+      const data = this.readSortQuery(this.$route.query.sort);
+      return data;
     },
     searchOptions() {
       switch (this.SearchEngine) {
@@ -250,7 +253,7 @@ export default {
         this.checkScrollPosition();
       }
     },
-    handleSortChanged({ field, order }) {
+    handleSortChange({ field, order }) {
       const sort = this.buildSortQuery(field, order);
       this.$router.replace({
         query: {
@@ -273,8 +276,7 @@ export default {
         const match = regexSort.exec(sortQuery);
         if (!match) return null;
         return {
-          field:
-            match.groups.field === FIELD_TRI_EFFECTIF ? "effectif" : "date",
+          field: match.groups.field,
           order: match.groups.order === "-" ? false : true,
         };
       } catch (error) {

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -141,7 +141,7 @@ export default {
     },
     sortDataForDisplay() {
       const data = this.searchRepository.readSortQuery(this.$route.query.sort);
-      console.log("Sort Query", data);
+      // console.log("Sort Query", data);
       return data;
     },
     searchOptions() {

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -49,7 +49,7 @@
         <OpenDataSoftResultList
           v-if="SearchEngine == 'OpenDataSoft'"
           :companies="items"
-          :sort="sortData"
+          :sort="sortDataForDisplay"
           @sortChanged="handleSortChange"
         />
         <EnthicResultList v-if="SearchEngine == 'Enthic'" :companies="items" />
@@ -86,9 +86,6 @@ import EnthicSearchRepository from "@/repositories/search/EnthicSearchRepository
 import OpenDataSoftSearchRepository from "@/repositories/search/OpenDataSoftSearchRepository";
 
 // import SearchRepository from "@/repositories/search/SearchRepository.fake";
-
-const FIELD_TRI_EFFECTIF = "trancheeffectifsunitelegaletriable";
-const FIELD_TRI_DATE = "datecreationunitelegale";
 
 export default {
   components: {
@@ -138,22 +135,13 @@ export default {
       if (!this.lastResults || !this.lastResults.view) return null;
       return this.lastResults.view.next;
     },
-    sortOption() {
+    sortStringForSearch() {
       if (this.SearchEngine !== "OpenDataSoft") return null;
       return this.$route.query.sort;
     },
-    sortEffectif() {
-      if (this.SearchEngine !== "OpenDataSoft") return null;
-      const sort = this.readSortQuery(this.$route.query.sort);
-      return sort?.field === FIELD_TRI_EFFECTIF ? sort.order : null;
-    },
-    sortDate() {
-      if (this.SearchEngine !== "OpenDataSoft") return null;
-      const sort = this.readSortQuery(this.$route.query.sort);
-      return sort?.field === FIELD_TRI_DATE ? sort.order : null;
-    },
-    sortData() {
-      const data = this.readSortQuery(this.$route.query.sort);
+    sortDataForDisplay() {
+      const data = this.searchRepository.readSortQuery(this.$route.query.sort);
+      console.log("Sort Query", data);
       return data;
     },
     searchOptions() {
@@ -161,7 +149,7 @@ export default {
         case "OpenDataSoft":
           return {
             text: this.text,
-            sort: this.sortOption,
+            sort: this.sortStringForSearch,
             offset: this.items ? this.items.length : 0,
           };
         case "Enthic":
@@ -265,24 +253,6 @@ export default {
     buildSortQuery(sortField, sortOrder) {
       if (sortOrder === true) return sortField;
       if (sortOrder === false) return "-" + sortField;
-      return null;
-    },
-    readSortQuery(sortQuery) {
-      if (!sortQuery) return null;
-      try {
-        const regexSort = new RegExp(
-          `(?<order>-?)(?<field>${FIELD_TRI_EFFECTIF}|${FIELD_TRI_DATE})`
-        );
-        const match = regexSort.exec(sortQuery);
-        if (!match) return null;
-        return {
-          field: match.groups.field,
-          order: match.groups.order === "-" ? false : true,
-        };
-      } catch (error) {
-        console.log("url regEx error", error);
-      }
-
       return null;
     },
   },

--- a/src/components/search/SortableTitle.vue
+++ b/src/components/search/SortableTitle.vue
@@ -1,0 +1,51 @@
+<template>
+  <a class="result-link" @click="toggleSort">
+    <span>
+      {{ name }}
+    </span>
+    <span v-if="sort === false">
+      <span class="icon icon-1">
+        <i class="fas fa-caret-down"></i>
+      </span>
+    </span>
+    <span v-else-if="sort === true">
+      <span class="icon icon-1">
+        <i class="fas fa-caret-up"></i>
+      </span>
+    </span>
+  </a>
+</template>
+
+<script>
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    sort: {
+      type: Boolean,
+      default: null,
+      required: false,
+    },
+  },
+  methods: {
+    toggleSort() {
+      const sort = this.rollSortValue(this.sort);
+      this.$emit("sortChanged", sort);
+    },
+    rollSortValue(currentValue) {
+      if (currentValue === null || currentValue === "") return true;
+      if (currentValue === true) return false;
+      return null;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.icon-1 {
+  height: 1rem;
+  width: 1rem;
+}
+</style>

--- a/src/components/search/SortableTitle.vue
+++ b/src/components/search/SortableTitle.vue
@@ -18,10 +18,6 @@
 
 <script>
 export default {
-  model: {
-    prop: "sortOrder",
-    event: "sortOrderChanged",
-  },
   props: {
     name: {
       type: String,

--- a/src/components/search/SortableTitle.vue
+++ b/src/components/search/SortableTitle.vue
@@ -18,6 +18,10 @@
 
 <script>
 export default {
+  model: {
+    prop: "sortOrder",
+    event: "sortOrderChanged",
+  },
   props: {
     name: {
       type: String,

--- a/src/components/search/SortableTitle.vue
+++ b/src/components/search/SortableTitle.vue
@@ -3,12 +3,12 @@
     <span>
       {{ name }}
     </span>
-    <span v-if="sort === false">
+    <span v-if="sortOrder === false">
       <span class="icon icon-1">
         <i class="fas fa-caret-down"></i>
       </span>
     </span>
-    <span v-else-if="sort === true">
+    <span v-else-if="sortOrder === true">
       <span class="icon icon-1">
         <i class="fas fa-caret-up"></i>
       </span>
@@ -23,7 +23,7 @@ export default {
       type: String,
       required: true,
     },
-    sort: {
+    sortOrder: {
       type: Boolean,
       default: null,
       required: false,
@@ -31,8 +31,8 @@ export default {
   },
   methods: {
     toggleSort() {
-      const sort = this.rollSortValue(this.sort);
-      this.$emit("sortChanged", sort);
+      const newSortOrder = this.rollSortValue(this.sortOrder);
+      this.$emit("sortOrderChanged", newSortOrder);
     },
     rollSortValue(currentValue) {
       if (currentValue === null || currentValue === "") return true;

--- a/src/repositories/search/EnthicSearchRepository.js
+++ b/src/repositories/search/EnthicSearchRepository.js
@@ -1,6 +1,11 @@
 import { apiClient } from "../ServerConfiguration";
 
 export default {
+  fields: {},
+  readSortQuery(sortQuery) {
+    if (!sortQuery) return null;
+    return null;
+  },
   async searchFirstPage(enthicSearchOptions) {
     const { text } = enthicSearchOptions;
     if (!text) return null;

--- a/src/repositories/search/OpenDataSoftSearchRepository.js
+++ b/src/repositories/search/OpenDataSoftSearchRepository.js
@@ -10,6 +10,28 @@ export const opendatasoftApiClient = axios.create({
 });
 
 export default {
+  fields: {
+    FIELD_TRI_EFFECTIF: "trancheeffectifsunitelegaletriable",
+    FIELD_TRI_DATE: "datecreationunitelegale",
+  },
+  readSortQuery(sortQuery) {
+    if (!sortQuery) return null;
+    try {
+      const regexSort = new RegExp(
+        `(?<order>-?)(?<field>${this.fields.FIELD_TRI_EFFECTIF}|${this.fields.FIELD_TRI_DATE})`
+      );
+      const match = regexSort.exec(sortQuery);
+      if (!match) return null;
+      return {
+        field: match.groups.field,
+        order: match.groups.order === "-" ? false : true,
+      };
+    } catch (error) {
+      console.log("url regEx error", error);
+    }
+
+    return null;
+  },
   async searchFirstPage(openDataSoftSearchOptions) {
     const { text, sort } = openDataSoftSearchOptions;
     if (!text) return null;
@@ -33,7 +55,7 @@ export default {
   },
 
   formatResult(results) {
-    console.log("results from OpenDataSoft:", results.data.records);
+    // console.log("results from OpenDataSoft:", results.data.records);
     return results
       ? { ...results.data, records: null, items: results.data.records }
       : null;

--- a/test/opendatasoft.http
+++ b/test/opendatasoft.http
@@ -1,0 +1,3 @@
+
+### sort by datecreationunitelegale
+https://data.opendatasoft.com/api/records/1.0/search/?dataset=economicref-france-sirene-v3@public&q=enercoop&rows=30&refine.etablissementsiege=oui&refine.etatadministratifunitelegale=Active&start=0&sort=datecreationunitelegale

--- a/test/opendatasoft.http
+++ b/test/opendatasoft.http
@@ -1,3 +1,10 @@
 
 ### sort by datecreationunitelegale
 https://data.opendatasoft.com/api/records/1.0/search/?dataset=economicref-france-sirene-v3@public&q=enercoop&rows=30&refine.etablissementsiege=oui&refine.etatadministratifunitelegale=Active&start=0&sort=datecreationunitelegale
+
+
+### sort by Effectif DESC
+https://data.opendatasoft.com/api/records/1.0/search/?dataset=economicref-france-sirene-v3@public&q=enercoop&rows=30&refine.etablissementsiege=oui&refine.etatadministratifunitelegale=Active&start=0&sort=trancheeffectifsunitelegaletriable
+
+### sort by Effectif ASC
+https://data.opendatasoft.com/api/records/1.0/search/?dataset=economicref-france-sirene-v3@public&q=enercoop&rows=30&refine.etablissementsiege=oui&refine.etatadministratifunitelegale=Active&start=0&sort=-trancheeffectifsunitelegaletriable


### PR DESCRIPTION
J'ai tenté de rendre cliquable les titres des colonnes "Effectif" et "Dates" dans la page listant les résultats de recherche, pour pouvoir trier ces résultats selon la taille et l'age de l'entreprise. Malheureusement, quand on clique, il ne se passe rien, et il semblerait que je n'utilise pas du tout la bonne méthode pour générer un lien, puisque celui de la colonne "Dates" semble écraser celui de la colonne "Effectif".
Help!!! :-)